### PR TITLE
Make tests work in 2017

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    install_requires=['thrift >= 0.9.1'],
-    tests_require=['mock >= 1.0', 'unittest2 >= 0.5.1'],
+    install_requires=['thrift < 0.10'],
+    tests_require=['mock == 1.0', 'unittest2 >= 0.5.1'],
     extras_require={
         'configglue_support': ['configglue']
     },


### PR DESCRIPTION
* Force Thrift version to be lower than 0.10.0
* Freeze Mock version to 1.0.0